### PR TITLE
chore(docs): point RUNBOOK already-migrated list at registry instead …

### DIFF
--- a/scripts/migration/RUNBOOK.md
+++ b/scripts/migration/RUNBOOK.md
@@ -40,8 +40,10 @@ Refer to **[SERVICE_REGISTRY.md](SERVICE_REGISTRY.md)** for:
 - Priority order (dependencies between services).
 - Owner / sprint, where assigned.
 
-**Already migrated** (don't re-run unless you mean to):
-- `lock-svc`, `case`, `order`, `bank-details`, `Notification`.
+**Already migrated** — see the `done` rows in
+[SERVICE_REGISTRY.md](SERVICE_REGISTRY.md) (don't re-run unless you
+mean to). The registry is the canonical source; this file used to
+duplicate the list but it kept going stale.
 
 ---
 


### PR DESCRIPTION
…of duplicating

RUNBOOK §1 used to hardcode a list of done services — kept going stale (was lock-svc/case/order at one point, then bumped to +bank-details/+Notification, missing template-configuration after PR #61). Replace with a pointer to SERVICE_REGISTRY.md, which is already the canonical source per the parallel-migration kickoff. Removes a per-merge maintenance step that was being skipped anyway.

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
