### PR TITLE
chore(migration): mark inportal-survey as done in registry

### DIFF
--- a/scripts/migration/SERVICE_REGISTRY.md
+++ b/scripts/migration/SERVICE_REGISTRY.md
@@ -48,7 +48,7 @@ Core case-lifecycle domain — the bulk of DRISTI.
 | `ctc` | 125 | pending | `case-lifecycle` | `ctc` | |
 | `template-configuration` | 29 | **done** | `case-lifecycle` | `templateconfiguration` | First migration on the parallel-migration kickoff recipe; leaf-service path validated (no `*Api`, `@ApplicationModule` for boundary, Rule 40 scan clean) |
 | `ab-diary` | 91 | **done** | `case-lifecycle` | `abdiary` | Two-PR split (#66 structural+uplift, #68 dead-code sweep + Phase 4a revert). A-diary live; B-diary case-fetch deferred — wire `CaseApi` directly when resumed (Rule 32). FileStoreUtil lift to dristi-common deferred to its own Tier 3 PR |
-| `inportal-survey` | 43 | pending | `case-lifecycle` | `inportalsurvey` | |
+| `inportal-survey` | 43 | **done** | `case-lifecycle` | `inportalsurvey` | Second leaf service after `template-configuration` (0 intra-DRISTI REST calls); 12 contract DTOs Phase-35-lifted to `dristi-common/contract/inportalsurvey/`; `@ApplicationModule` boundary marker, no `*Api` (no callers yet). Merge resolution (PR #64) surfaced that Pipeline 5 mechanically re-adds REST host keys to subdomain overlays after REST→direct cleanup commits → `SERVICE_DEAD_KEYS` denylist added in `run_consolidation.py` (483b71f8c) so ab-diary's `dristi.case.*` and payment-calculator's `egov.case.*` stay suppressed across future regens |
 | `scheduler-svc` | 237 | pending | `case-lifecycle` | `scheduler` | depends on `hearing` |
 | `openapi` | 260 | pending | `case-lifecycle` | `openapi` | |
 


### PR DESCRIPTION
PR #64 merged to monolith/main as b3f23e4f4 on 2026-05-11. Lifted inportal-survey into domain-case-lifecycle/inportalsurvey; second leaf service after template-configuration (0 intra-DRISTI REST calls, no *Api). 12 contract DTOs Phase-35-lifted to
dristi-common/contract/inportalsurvey/.

Merge-resolution session surfaced a Pipeline 5 regression: subdomain overlays mechanically re-acquired REST host keys (dristi.case.*, egov.case.*) that earlier REST→direct cleanup commits (d18c5b552 ab-diary, a60c86086 payment-calculator) had removed. Fix landed in the merge commit 483b71f8c: SERVICE_DEAD_KEYS denylist in run_consolidation.py drops the keys at consolidation time so future regens stay clean.

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
