### PR TITLE
feat(transformer): isolate Kafka consumer factory with StringDeserial…

### DIFF
--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/config/TransformerKafkaConfig.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/config/TransformerKafkaConfig.java
@@ -1,0 +1,59 @@
+package org.pucar.dristi.caselifecycle.transformer.internal.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// Transformer @KafkaListeners cast payload.value() directly to String and run
+// Jackson manually. The monolith default ConsumerFactory uses HashMapDeserializer
+// (see dristi-app/src/main/resources/application.yml), so transformer needs its
+// own factory wired to StringDeserializer. Every transformer @KafkaListener must
+// reference this factory via containerFactory = "stringKafkaListenerContainerFactory".
+@Configuration
+public class TransformerKafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Value("${kafka.consumer.config.auto_offset_reset:earliest}")
+    private String autoOffsetReset;
+
+    @Value("${kafka.consumer.config.auto_commit:true}")
+    private boolean autoCommit;
+
+    @Value("${kafka.consumer.config.auto_commit_interval:100}")
+    private int autoCommitInterval;
+
+    @Value("${kafka.consumer.config.session_timeout:15000}")
+    private int sessionTimeout;
+
+    @Bean
+    public ConsumerFactory<String, Object> transformerConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "transformer");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, autoCommit);
+        props.put(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, autoCommitInterval);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, sessionTimeout);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean("stringKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, Object> stringKafkaListenerContainerFactory(
+            ConsumerFactory<String, Object> transformerConsumerFactory) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(transformerConsumerFactory);
+        return factory;
+    }
+}

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/ApplicationConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/ApplicationConsumer.java
@@ -32,25 +32,25 @@ public class ApplicationConsumer {
         this.transformerProperties = transformerProperties;
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.create.application.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.create.application.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveApplication(ConsumerRecord<String, Object> payload,
                                 @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishApplication(payload, transformerProperties.getSaveApplicationTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.update.application.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.update.application.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateApplication(ConsumerRecord<String, Object> payload,
                                   @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishApplication(payload, transformerProperties.getUpdateApplicationTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.application.status.update.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.application.status.update.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateApplicationStatus(ConsumerRecord<String, Object> payload,
                                   @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishApplication(payload, transformerProperties.getUpdateApplicationTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.application.comments.update.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.application.comments.update.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateApplicationComments(ConsumerRecord<String, Object> payload,
                                         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishApplication(payload, transformerProperties.getUpdateApplicationTopic());

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/CaseConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/CaseConsumer.java
@@ -75,7 +75,7 @@ public class CaseConsumer {
         return null;
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.create.case.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.create.case.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveCase(ConsumerRecord<String, Object> payload,
                          @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishCase(payload, transformerProperties.getSaveCaseTopic());
@@ -83,7 +83,7 @@ public class CaseConsumer {
         publishCaseSearchFromCaseRequest(caseRequest);
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.update.case.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.update.case.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateCase(ConsumerRecord<String, Object> payload,
                            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishCase(payload, transformerProperties.getUpdateCaseTopic());
@@ -119,7 +119,7 @@ public class CaseConsumer {
         publishCaseSearchFromCaseRequest(caseRequest);
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.case.status.update.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.case.status.update.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateCaseStatus(ConsumerRecord<String, Object> payload,
                            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishCase(payload, transformerProperties.getUpdateCaseTopic());
@@ -127,24 +127,24 @@ public class CaseConsumer {
         publishCaseSearchFromCaseRequest(caseRequest);
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.join.case.kafka.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.join.case.kafka.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateJoinCase(ConsumerRecord<String, Object> payload,
                            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishCase(payload, transformerProperties.getUpdateCaseTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.case.overall.status.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.case.overall.status.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateCaseOverallStatus(ConsumerRecord<String, Object> payload,
                                         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         fetchAndPublishCaseForOverAllStatus(payload, transformerProperties.getUpdateCaseTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.edit.case.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.edit.case.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void editCase(ConsumerRecord<String, Object> payload, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         fetchAndPublishEditCase(payload, transformerProperties.getUpdateCaseTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.case.outcome.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.case.outcome.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateCaseOutcome(ConsumerRecord<String, Object> payload,
                                   @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         fetchAndPublishCaseForOutcome(payload, transformerProperties.getUpdateCaseTopic());
@@ -259,7 +259,7 @@ public class CaseConsumer {
         producer.push("case-legacy-topic", caseResponse);
     }
 
-    @KafkaListener(topics = {"${case.kafka.edit.topic}"})
+    @KafkaListener(topics = {"${case.kafka.edit.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void consumeCaseRequest(ConsumerRecord<String, Object> payload,
                                    @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         CaseRequest caseRequest = deserializeConsumerRecordIntoCaseRequest(payload);
@@ -267,7 +267,7 @@ public class CaseConsumer {
     }
 
 
-    @KafkaListener(topics = {"${egov.update.additional.join.case.kafka.topic}"})
+    @KafkaListener(topics = {"${egov.update.additional.join.case.kafka.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void consumeCourtCase(ConsumerRecord<String, Object> payload,
                                  @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishCaseSearchFromCourtCase(payload, transformerProperties.getCaseSearchTopic());
@@ -275,7 +275,7 @@ public class CaseConsumer {
 
     @KafkaListener(topics = {"${egov.litigant.join.case.kafka.topic}",
             "${egov.representative.join.case.kafka.topic}",
-            "${egov.update.representative.join.case.kafka.topic}"})
+            "${egov.update.representative.join.case.kafka.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void consumeJoinCaseRequest(ConsumerRecord<String, Object> payload, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         try {
             JoinCaseRequest joinCaseRequest = objectMapper.readValue((String) payload.value(), new TypeReference<>() {});
@@ -287,7 +287,7 @@ public class CaseConsumer {
         }
     }
 
-    @KafkaListener(topics = {"${egov.additional.join.case.kafka.topic}"})
+    @KafkaListener(topics = {"${egov.additional.join.case.kafka.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void consumeAddWitnessRequest(ConsumerRecord<String, Object> payload, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         try {
             AddWitnessRequest addWitnessRequest = objectMapper.readValue((String) payload.value(), new TypeReference<>() {});
@@ -308,7 +308,7 @@ public class CaseConsumer {
         return RequestInfo.builder().userInfo(userInfo).msgId(msgId).build();
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.case.overall.status.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.case.overall.status.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void consumeCaseStageSubstage(ConsumerRecord<String, Object> payload, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         try {
             CaseStageSubStage caseStageSubStage = objectMapper.readValue((String) payload.value(), new TypeReference<>() {});
@@ -321,7 +321,7 @@ public class CaseConsumer {
         }
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.case.reference.number.update}"})
+    @KafkaListener(topics = {"${transformer.consumer.case.reference.number.update}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateCaseReferenceNumber(ConsumerRecord<String, Object> payload,
                                           @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         CaseReferenceNumberUpdateRequest caseReferenceNumberUpdateRequest = deserializeConsumerRecordIntoCaseReferenceNumberUpdateRequest(payload);

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/DigitalizedDocumentConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/DigitalizedDocumentConsumer.java
@@ -35,7 +35,7 @@ public class DigitalizedDocumentConsumer {
             "${transformer.consumer.create.mediation.document.topic}",
             "${transformer.consumer.update.mediation.document.topic}",
             "${transformer.consumer.create.plea.document.topic}",
-            "${transformer.consumer.update.plea.document.topic}"})
+            "${transformer.consumer.update.plea.document.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveDigitalizedDocument(ConsumerRecord<String, Object> payload,
                                         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic){
         publishDigitalizedDocument(payload, topic);

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/EvidenceConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/EvidenceConsumer.java
@@ -47,7 +47,7 @@ public class EvidenceConsumer {
     }
 
     @KafkaListener(topics = {"${transformer.consumer.save.artifact.topic}",
-            "${transformer.consumer.save.withoutworkflow.artifact.topic}"})
+            "${transformer.consumer.save.withoutworkflow.artifact.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveArtifact(ConsumerRecord<String, Object> payload,
                              @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishArtifact(payload, topic);

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/HearingConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/HearingConsumer.java
@@ -41,25 +41,25 @@ public class HearingConsumer {
         this.caseService = caseService;
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.create.hearing.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.create.hearing.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveHearing(ConsumerRecord<String, Object> payload,
                             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishHearing(payload, transformerProperties.getSaveHearingTopic(),true);
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.update.hearing.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.update.hearing.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateHearing(ConsumerRecord<String, Object> payload,
                               @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishHearing(payload, transformerProperties.getUpdateHearingTopic(),false);
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.update.start.end.time.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.update.start.end.time.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateStartEndTime(ConsumerRecord<String, Object> payload,
                               @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishHearing(payload, transformerProperties.getUpdateHearingTopic(),true);
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.bulk.reschedule.hearing}"})
+    @KafkaListener(topics = {"${transformer.consumer.bulk.reschedule.hearing}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void bulkRescheduleHearing(ConsumerRecord<String, Object> payload,
                               @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishBulkHearing(payload, transformerProperties.getUpdateHearingTopic());

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/NotificationConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/NotificationConsumer.java
@@ -28,7 +28,7 @@ public class NotificationConsumer {
     }
 
 
-    @KafkaListener(topics = {"${transformer.consumer.update.notification.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.update.notification.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateOrder(ConsumerRecord<String, Object> payload,
                             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/OrderConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/OrderConsumer.java
@@ -39,7 +39,7 @@ public class OrderConsumer {
         this.eventManager = eventManager;
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.create.order.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.create.order.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveOrder(ConsumerRecord<String, Object> payload,
                           @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         try {
@@ -51,7 +51,7 @@ public class OrderConsumer {
 
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.update.order.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.update.order.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateOrder(ConsumerRecord<String, Object> payload,
                             @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 

--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/TaskConsumer.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/transformer/internal/consumer/TaskConsumer.java
@@ -35,13 +35,13 @@ public class TaskConsumer {
 
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.create.task.topic}", "${transformer.consumer.update.task.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.create.task.topic}", "${transformer.consumer.update.task.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void saveTask(ConsumerRecord<String, Object> payload,
                          @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishTask(payload, transformerProperties.getSaveTaskTopic());
     }
 
-    @KafkaListener(topics = {"${transformer.consumer.create.task.topic}", "${transformer.consumer.update.task.topic}"})
+    @KafkaListener(topics = {"${transformer.consumer.create.task.topic}", "${transformer.consumer.update.task.topic}"}, containerFactory = "stringKafkaListenerContainerFactory")
     public void updateTask(ConsumerRecord<String, Object> payload,
                            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
         publishTask(payload, transformerProperties.getUpdateTaskTopic());


### PR DESCRIPTION
…izer

Monolith default ConsumerFactory uses HashMapDeserializer for every service, but transformer @KafkaListeners cast payload.value() to String and run Jackson manually — which fails at runtime against HashMap values. Add a dedicated TransformerKafkaConfig that publishes a stringKafkaListenerContainerFactory backed by StringDeserializer (group-id "transformer"), and wire every transformer @KafkaListener to it via containerFactory.

## Requirements



- [ ] This PR has a proper title that briefly describes the work done
- [ ] Please ensure the branch name follows naming convention - feature-githubissunumber-xxx, bug-githubissunumber-xxx, enhance-githubissunumber-xxx.
- [ ] I have referenced the  github issues('s)
- [ ] I performed a self-review of my own code
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added proper logs and comments for the developed code
- [ ] If this PR includes MDMS, workflow data, or deployment configuration changes:
  - [ ] I have added MDMS data changes to `support/release-<release-number>-<issue-number>-mdms.json`
  - [ ] I have added workflow data changes to `support/release-<release-number>-<issue-number>-workflow.json`
  - [ ] I have added deployment configuration steps to `support/release-<release-number>/deployment.md`



## Summary
<!-- Please describe what problems your PR addresses. -->







## Data Changes
<!-- 
For MDMS or workflow changes, list the following:
- [ ] Files modified: `support/release-<release-number>-<issue-number>-mdms.json`
- [ ] Migration steps (if any):
-->



## Preview
<!-- Required if you are making UI changes. Attach Screenshots or Videos-->


## Other
<!-- 
Include any additional information such as:
- Breaking changes
- Dependencies added/removed
- Configuration changes
- Performance implications
- Security considerations
-->
