### PR TITLE
chore(analytics): mark 11 REST keys dead post-PR-#106 cutover

### DIFF
--- a/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/analytics/internal/config/Configuration.java
+++ b/dristi-monolith/domain-case-lifecycle/src/main/java/org/pucar/dristi/caselifecycle/analytics/internal/config/Configuration.java
@@ -64,9 +64,6 @@ public class Configuration {
 	@Value("${egov.case.host}")
 	private String caseHost;
 
-	@Value("${egov.case.search.endpoint}")
-	private String caseSearchPath;
-
 	@Value("${egov.advocate.case.search.endpoint}")
 	private String advocateCaseSearchPath;
 

--- a/dristi-monolith/domain-case-lifecycle/src/main/resources/application-analytics.yml
+++ b/dristi-monolith/domain-case-lifecycle/src/main/resources/application-analytics.yml
@@ -82,8 +82,6 @@ egov:
     outcome:
       topic: case-outcome-topic
     host: http://localhost:8099
-    search:
-      endpoint: /case/v1/_search
     member:
       advocates:
         endpoint: /case/v1/member/_advocates
@@ -92,21 +90,13 @@ egov:
   statelevel:
     tenantId: pb
   hearing:
-    host: http://localhost:8081
-    search:
-      endpoint: /hearing/v1/search
     business:
       services: hearing-default
   advocate:
     case:
       search:
         endpoint: /case/v1/advocate/_cases
-    host: http://localhost:8080/
-    path: advocate/v1/_search
   evidence:
-    host: http://localhost:8083
-    search:
-      endpoint: /evidence/v1/_search
     business:
       services: artifact-default,witness-deposition-default
   task:
@@ -129,9 +119,6 @@ egov:
     business:
       services: application-order-submission-default,application-order-submission-feedback,application-voluntary-submission,delay-condonation-submission
   order:
-    host: http://localhost:8086
-    search:
-      endpoint: /order/v1/search
     business:
       services: order-default
   adiary:
@@ -265,10 +252,6 @@ cache:
       masters:
         minutes: 15
 dristi:
-  task-management:
-    host: http://localhost:8080
-    search:
-      endpoint: /task-management/v1/_search
   ctc:
     host: http://localhost:8080
   ctc-application:

--- a/dristi-monolith/domain-case-lifecycle/src/test/java/org/pucar/dristi/caselifecycle/analytics/internal/config/ConfigurationTest.java
+++ b/dristi-monolith/domain-case-lifecycle/src/test/java/org/pucar/dristi/caselifecycle/analytics/internal/config/ConfigurationTest.java
@@ -74,7 +74,6 @@ class ConfigurationTest {
         configuration.setTimezone("UTC");
         configuration.setStateLevelTenantId("tenantId");
         configuration.setCaseHost("http://case-host");
-        configuration.setCaseSearchPath("/case/search");
         configuration.setTaskHost("http://task-host");
         configuration.setTaskSearchPath("/task/search");
         configuration.setApplicationHost("http://application-host");
@@ -95,7 +94,6 @@ class ConfigurationTest {
         assertEquals("UTC", configuration.getTimezone());
         assertEquals("tenantId", configuration.getStateLevelTenantId());
         assertEquals("http://case-host", configuration.getCaseHost());
-        assertEquals("/case/search", configuration.getCaseSearchPath());
         assertEquals("http://task-host", configuration.getTaskHost());
         assertEquals("/task/search", configuration.getTaskSearchPath());
         assertEquals("http://application-host", configuration.getApplicationHost());

--- a/scripts/migration/config_consolidation/output/config_consolidation_report.csv
+++ b/scripts/migration/config_consolidation/output/config_consolidation_report.csv
@@ -85,9 +85,7 @@ dristi.order.host,hearing,http://localhost:8051,CONFLICT
 dristi.order.host,task-management,http://localhost:8051,CONFLICT
 dristi.order.search.endpoint,hearing,/order/v1/search,CONFLICT
 dristi.order.search.endpoint,task-management,/order/v1/search,CONFLICT
-dristi.task-management.host,analytics,http://localhost:8080,CONFLICT
 dristi.task-management.host,hearing,http://localhost:8080,CONFLICT
-dristi.task-management.search.endpoint,analytics,/task-management/v1/_search,CONFLICT
 dristi.task-management.search.endpoint,hearing,/task-management/v1/_search,CONFLICT
 dristi.task.host,hearing,http://localhost:8054,CONFLICT
 dristi.task.host,task-management,http://localhost:8054,CONFLICT
@@ -99,11 +97,9 @@ egov-state-level-tenant-id,analytics,pb,CONFLICT
 egov-state-level-tenant-id,epost-tracker,pb,CONFLICT
 egov-state-level-tenant-id,inportal-survey,pb,CONFLICT
 egov-state-level-tenant-id,treasury-backend,pb,CONFLICT
-egov.advocate.host,analytics,http://localhost:8080/,CONFLICT
 egov.advocate.host,evidence,http://localhost:8080/,CONFLICT
 egov.advocate.host,hearing,http://localhost:8080/,CONFLICT
 egov.advocate.host,treasury-backend,http://localhost:8080/,CONFLICT
-egov.advocate.path,analytics,advocate/v1/_search,CONFLICT
 egov.advocate.path,evidence,advocate/v1/_search,CONFLICT
 egov.advocate.path,hearing,advocate/v1/_search,CONFLICT
 egov.advocate.path,treasury-backend,advocate/v1/_search,CONFLICT
@@ -150,7 +146,6 @@ egov.case.path,ctc,case/v1/_exists,CONFLICT
 egov.case.path,evidence,case/v1/_exists,CONFLICT
 egov.case.path,order,case/v1/_exists,CONFLICT
 egov.case.path,task,case/v1/_exists,CONFLICT
-egov.case.search.endpoint,analytics,/case/v1/_search,CONFLICT
 egov.case.search.endpoint,bail-bond,/case/v1/_search,CONFLICT
 egov.case.search.endpoint,digitalized-documents,/case/v1/_search,CONFLICT
 egov.case.search.endpoint,task,case/v1/_search,CONFLICT
@@ -193,7 +188,6 @@ egov.etreasury.host,ctc,http://localhost:8090,CONFLICT
 egov.etreasury.host,task-management,http://localhost:8076,CONFLICT
 egov.evidence.create.path,application,/evidence/v1/_create,CONFLICT
 egov.evidence.create.path,case,/evidence/v1/_create,CONFLICT
-egov.evidence.host,analytics,http://localhost:8083,CONFLICT
 egov.evidence.host,application,http://localhost:8080,CONFLICT
 egov.evidence.host,case,http://localhost:8089,CONFLICT
 egov.file.store.delete.endpoint,Notification,/filestore/v1/files/delete,CONFLICT
@@ -243,9 +237,7 @@ egov.filestore.search.endpoint,digitalized-documents,/filestore/v1/files/id,CONF
 egov.filestore.search.endpoint,e-sign-svc,filestore/v1/files/id,CONFLICT
 egov.filestore.search.endpoint,evidence,/filestore/v1/files/id,CONFLICT
 egov.filestore.search.endpoint,task,/filestore/v1/files/id,CONFLICT
-egov.hearing.host,analytics,http://localhost:8081,CONFLICT
 egov.hearing.host,evidence,http://localhost:8092/,CONFLICT
-egov.hearing.search.endpoint,analytics,/hearing/v1/search,CONFLICT
 egov.hearing.search.endpoint,evidence,/hearing/v1/search,CONFLICT
 egov.hrms.host,Notification,https://dev.digit.org,CONFLICT
 egov.hrms.host,ab-diary,https://dev.digit.org,CONFLICT
@@ -505,7 +497,6 @@ egov.mdms.search.endpoint,payment-calculator-svc,/egov-mdms-service/v1/_search,C
 egov.mdms.search.endpoint,task,/egov-mdms-service/v1/_search,CONFLICT
 egov.mdms.search.endpoint,task-management,/egov-mdms-service/v1/_search,CONFLICT
 egov.mdms.search.endpoint,treasury-backend,/egov-mdms-service/v1/_search,CONFLICT
-egov.order.host,analytics,http://localhost:8086,CONFLICT
 egov.order.host,application,http://localhost:8091/,CONFLICT
 egov.order.host,case,http://localhost:8086,CONFLICT
 egov.order.host,evidence,http://localhost:8091/,CONFLICT
@@ -513,7 +504,6 @@ egov.order.host,task,http://localhost:8085/,CONFLICT
 egov.order.path,application,order/v1/exists,CONFLICT
 egov.order.path,evidence,order/v1/exists,CONFLICT
 egov.order.path,task,order/v1/exists,CONFLICT
-egov.order.search.endpoint,analytics,/order/v1/search,CONFLICT
 egov.order.search.endpoint,case,/order/v1/search,CONFLICT
 egov.pdf.service.create.endpoint,ab-diary,/pdf-service/v1/_createnosave,CONFLICT
 egov.pdf.service.create.endpoint,epost-tracker,/pdf-service/v1/_createnosave,CONFLICT
@@ -1361,7 +1351,6 @@ egov.enc.mdms.security.policy.court.decrypt.other,case,CaseDecryptOther,SERVICE-
 egov.etreasury.create.demand.path,application,/etreasury/payment/v1/_createDemand,SERVICE-SPECIFIC
 egov.etreasury.payment.receipt.endpoint,ctc,/etreasury/payment/v1/_getPaymentReceipt,SERVICE-SPECIFIC
 egov.evidence.business.services,analytics,"artifact-default,witness-deposition-default",SERVICE-SPECIFIC
-egov.evidence.search.endpoint,analytics,/evidence/v1/_search,SERVICE-SPECIFIC
 egov.file.store.host,treasury-backend,http://egov-filestore:8080,SERVICE-SPECIFIC
 egov.file.store.treasury.module,treasury-backend,treasury,SERVICE-SPECIFIC
 egov.filestore.case.module,case,case,SERVICE-SPECIFIC

--- a/scripts/migration/config_consolidation/run_consolidation.py
+++ b/scripts/migration/config_consolidation/run_consolidation.py
@@ -220,6 +220,30 @@ SERVICE_DEAD_KEYS: dict[str, set[str]] = {
         "dristi.advocate.search.endpoint",
         "dristi.advocate.clerk.search.endpoint",
     },
+    # 73eef3e08 refactor(analytics): contract uplift + REST→direct calls
+    # (PR #106). Rule 37 dropped the @Value bindings from
+    # caselifecycle/analytics/internal/config/Configuration.java for the
+    # six utils converted to direct *Api calls (Advocate/Case/Evidence/
+    # Hearing/Order/TaskManagement). egov.case.search.endpoint joined the
+    # set after analytics CaseUtil.searchCaseDetails was rewired onto
+    # CaseApi.search; egov.{advocate.{host,path}} fell out with the
+    # Rule 38 deletion of analytics AdvocateUtil. egov.{case.host,
+    # case.member.advocates.endpoint, advocate.case.search.endpoint} stay
+    # live — CaseUtil.{getCasesByAdvocateId,getAdvocatesForMember} are
+    # the Rule 39 deferrals with no matching *Api method yet.
+    "analytics": {
+        "egov.advocate.host",
+        "egov.advocate.path",
+        "egov.case.search.endpoint",
+        "egov.evidence.host",
+        "egov.evidence.search.endpoint",
+        "egov.hearing.host",
+        "egov.hearing.search.endpoint",
+        "egov.order.host",
+        "egov.order.search.endpoint",
+        "dristi.task-management.host",
+        "dristi.task-management.search.endpoint",
+    },
 }
 
 # Two-source-into-one-subdomain (e-sign-svc + esign-interceptor): the


### PR DESCRIPTION
## Summary

Follow-up to PR #106 — closes the regen window before the next `migrate(<service>): structural lift` PR triggers a `run_consolidation.py` regen.

PR #106 (`73eef3e08`) converted six analytics utils to direct `*Api` calls (Advocate/Case/Evidence/Hearing/Order/TaskManagement) and Rule-38-deleted analytics `AdvocateUtil`. Rule 37 dropped the matching `@Value` bindings from analytics `Configuration.java`, but the source `dristi-services/analytics/.../application.properties` still carries the 11 keys — so the next consolidator regen would carry them back into `application-analytics.yml`.

Also drops `egov.case.search.endpoint` (analytics-only): `analyticsConfiguration.caseSearchPath` had no remaining consumer after `CaseUtil.searchCaseDetails` was rewired onto `CaseApi.search`.

### Dead keys registered

```
egov.advocate.host                       egov.evidence.host
egov.advocate.path                       egov.evidence.search.endpoint
egov.case.search.endpoint                egov.hearing.host
egov.order.host                          egov.hearing.search.endpoint
egov.order.search.endpoint               dristi.task-management.host
dristi.task-management.search.endpoint
```

### Changes

- `scripts/migration/config_consolidation/run_consolidation.py` — add `SERVICE_DEAD_KEYS["analytics"]` with citation to `73eef3e08`.
- `analytics/internal/config/Configuration.java` — drop dead `caseSearchPath` `@Value` field.
- `analytics/internal/config/ConfigurationTest.java` — drop matching setter / `getCaseSearchPath` assertion.
- `application-analytics.yml` — prune 11 dead-key entries.
- `output/config_consolidation_report.csv` — remove 11 dead-key rows.

### What stays live

`egov.case.host`, `egov.case.member.advocates.endpoint`, `egov.advocate.case.search.endpoint` — analytics `CaseUtil.{getCasesByAdvocateId, getAdvocatesForMember}` are Rule 39 deferrals (no matching `CaseApi` method yet).

Same pattern as `5f37fc2ca chore(case): mark egov.evidence.search.path dead post-EvidenceApi cutover`.

## Test plan

- [x] `mvn -pl domain-case-lifecycle -am test -Dtest=ConfigurationTest` — analytics `ConfigurationTest` (2 tests) passes
- [x] `python3 -c 'import ast; ast.parse(open(\"run_consolidation.py\").read())'` — script syntax OK
- [x] `python3 -c 'import yaml; yaml.safe_load(open(\"application-analytics.yml\"))'` — YAML valid
- [ ] Run `python3 run_consolidation.py --service analytics ...` post-merge and confirm none of the 11 keys reappear in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)